### PR TITLE
fix(ci): watch every pinned digest, not a list written by hand

### DIFF
--- a/.github/workflows/deployment-verification.yml
+++ b/.github/workflows/deployment-verification.yml
@@ -128,8 +128,17 @@ jobs:
       - name: Compare pinned digests against what each tag resolves to now
         run: |
           status=0
-          for var in NEXTCLOUD_POSTGRES_IMAGE_TAG NEXTCLOUD_REDIS_IMAGE_TAG NEXTCLOUD_IMAGE_TAG ONLYOFFICE_DOCUMENT_IMAGE_TAG RABBITMQ_IMAGE_TAG TRAEFIK_IMAGE_TAG; do
+          # Enumerated from the compose file, never listed here. A list written
+          # by hand falls behind the file it describes: pins added to x-images
+          # and not to this line are never compared against the registry, and
+          # the job stays green while saying nothing about them.
+          vars="$(grep -oE '\$\{[A-Z0-9_]+_IMAGE_TAG:-' nextcloud-onlyoffice-traefik-letsencrypt-docker-compose.yml | sed -E 's/^\$\{//; s/:-$//' | sort -u)"
+          for var in $vars; do
             pin="$(grep -m1 -oE "\\$\\{${var}:-.*" nextcloud-onlyoffice-traefik-letsencrypt-docker-compose.yml | sed -E -e ':a' -e 's/\$\{[A-Z0-9_]+:-([^{}]*)\}/\1/' -e 'ta')"
+            # An image built from source has no published digest, so there is
+            # nothing to compare and a lookup would fail on a name no registry
+            # serves. Enumeration reaches those pins; this skips them.
+            case "$pin" in *@sha256:*) ;; *) continue ;; esac
             ref="${pin%%@*}"
             pinned_digest="${pin##*@}"
             # Three attempts: an unanswered registry lookup used to leave this empty,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _(no unreleased changes yet)_
 
+## [1.6.1] - 2026-09-06
+
+### Fixed
+
+- **Two pinned images were never compared against the registry.** The
+  freshness job iterated a list of variable names written by hand, and the
+  document server own PostgreSQL and Redis pins were not on it. Both are
+  digest pins: `postgres:16` and `redis:7.4` are rebuilt regularly under the
+  same tag, which is exactly the kind of repush this job exists to catch. Both
+  are current as of today, which is luck rather than a result.
+
+### Changed
+
+- **The job enumerates the pins out of the compose file instead of naming
+  them.** A pin that exists is a pin that is watched, and a list cannot fall
+  behind the file it describes. An image built from source is skipped rather
+  than looked up under a name no registry serves.
+
 ## [1.6.0] - 2026-09-04
 
 ### Fixed
@@ -191,7 +209,8 @@ v1.2.0.
   requires Nextcloud's `status.php` to report `installed:true` and the
   ONLYOFFICE `/healthcheck` to return `true`, both through Traefik.
 
-[Unreleased]: https://github.com/heyvaldemar/nextcloud-onlyoffice-traefik-letsencrypt-docker-compose/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/heyvaldemar/nextcloud-onlyoffice-traefik-letsencrypt-docker-compose/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/heyvaldemar/nextcloud-onlyoffice-traefik-letsencrypt-docker-compose/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/heyvaldemar/nextcloud-onlyoffice-traefik-letsencrypt-docker-compose/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/heyvaldemar/nextcloud-onlyoffice-traefik-letsencrypt-docker-compose/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/heyvaldemar/nextcloud-onlyoffice-traefik-letsencrypt-docker-compose/compare/v1.4.0...v1.4.1


### PR DESCRIPTION
The freshness job in this repository was watching six pins. The compose file has eight.

`ONLYOFFICE_DOCUMENT_POSTGRES_IMAGE_TAG` and `ONLYOFFICE_DOCUMENT_REDIS_IMAGE_TAG` were pinned by digest and compared against nothing. Both are `postgres:16` and `redis:7.4`, tags rebuilt regularly under the same name, which is the exact case this job exists to catch. The Nextcloud PostgreSQL and Redis pins were on the list; the document server pair was not.

I resolved all eight against the registry before writing this: every one matches what its tag serves today. That is luck, not a result.

The hand-written list is gone. The loop enumerates `*_IMAGE_TAG` defaults out of the compose file, so a pin that exists is a pin that is watched. A pin with no digest, an image built from source, is skipped rather than looked up under a name no registry serves.

The same audit ran across every template in the fleet. Two repositories had unwatched digest pins: this one and mailu.
